### PR TITLE
[misc] Add auxiliary parameters (for release test runner), perf fixes

### DIFF
--- a/examples/billiards.py
+++ b/examples/billiards.py
@@ -161,7 +161,7 @@ def optimize():
     for iter in range(200):
         clear()
 
-        with ti.Tape(loss):
+        with ti.ad.Tape(loss):
             if iter % 20 == 19:
                 output = 'iter{:04d}'.format(iter)
             else:

--- a/examples/diffmpm.py
+++ b/examples/diffmpm.py
@@ -1,4 +1,5 @@
 import taichi as ti
+import argparse
 import os
 import math
 import numpy as np
@@ -325,10 +326,11 @@ def visualize(s, folder):
     aid = actuator_id.to_numpy()
     colors = np.empty(shape=n_particles, dtype=np.uint32)
     particles = x.to_numpy()[s]
+    actuation_ = actuation.to_numpy()
     for i in range(n_particles):
         color = 0x111111
         if aid[i] != -1:
-            act = actuation[s - 1, int(aid[i])]
+            act = actuation_[s - 1, int(aid[i])]
             color = ti.rgb_to_hex((0.5 - act, 0.5 - abs(act), 0.5 + act))
         colors[i] = color
     gui.circles(pos=particles, color=colors, radius=1.5)
@@ -339,6 +341,10 @@ def visualize(s, folder):
 
 
 def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument('--iters', type=int, default=100)
+    options = parser.parse_args()
+
     # initialization
     scene = Scene()
     robot(scene)
@@ -356,8 +362,8 @@ def main():
         particle_type[i] = scene.particle_type[i]
 
     losses = []
-    for iter in range(100):
-        with ti.Tape(loss):
+    for iter in range(options.iters):
+        with ti.ad.Tape(loss):
             forward()
         l = loss[None]
         losses.append(l)

--- a/examples/diffmpm_benchmark.py
+++ b/examples/diffmpm_benchmark.py
@@ -228,25 +228,27 @@ def benchmark():
     ti.print_kernel_profile_info()
 
 
-def main():
-    place()
-    # initialization
+@ti.kernel
+def init():
     init_v[None] = [0, 0]
 
     for i in range(n_particles):
         F[0, i] = [[1, 0], [0, 1]]
 
-    for i in range(N):
-        for j in range(N):
-            x[0, i * N + j] = [dx * (i * 0.5 + 10), dx * (j * 0.5 + 25)]
+    for i, j in ti.ndrange(N, N):
+        x[0, i * N + j] = [dx * (i * 0.5 + 10), dx * (j * 0.5 + 25)]
 
+
+def main():
+    place()
+    init()
     set_v()
     benchmark()
 
     losses = []
     img_count = 0
     for i in range(30):
-        with ti.Tape(loss=loss):
+        with ti.ad.Tape(loss=loss):
             set_v()
             for s in range(steps - 1):
                 substep(s)

--- a/examples/diffmpm_simple.py
+++ b/examples/diffmpm_simple.py
@@ -171,7 +171,7 @@ for i in range(30):
     grid_m_in.fill(0)
 
     x_avg[None] = [0, 0]
-    with ti.Tape(loss=loss):
+    with ti.ad.Tape(loss=loss):
         set_v()
         for s in range(steps - 1):
             substep(s)

--- a/examples/electric.py
+++ b/examples/electric.py
@@ -190,7 +190,7 @@ def optimize():
         output = None
         if vis:
             output = 'iter{:05d}'.format(iter)
-        with ti.Tape(loss):
+        with ti.ad.Tape(loss):
             forward(visualize=vis, output=output)
         losses.append(loss[None])
         # print(iter, "loss", loss[None])

--- a/examples/liquid.py
+++ b/examples/liquid.py
@@ -425,10 +425,12 @@ def main():
     scene.finalize()
     allocate_fields()
 
+    print(':: rand')
     for i in range(n_actuators):
         for j in range(n_sin_waves):
             weights[i, j] = np.random.randn() * 0.01
 
+    print(':: particles')
     for i in range(scene.n_particles):
         x[0, i] = scene.x[i]
         F[0, i] = [[1, 0, 0], [0, 1, 0], [0, 0, 1]]

--- a/examples/mass_spring.py
+++ b/examples/mass_spring.py
@@ -1,4 +1,5 @@
 from mass_spring_robot_config import robots
+import argparse
 import random
 import sys
 import matplotlib.pyplot as plt
@@ -314,10 +315,10 @@ def optimize(toi, visualize):
 
     losses = []
     # forward('initial{}'.format(robot_id), visualize=visualize)
-    for iter in range(100):
+    for iter in range(options.iters):
         clear()
-        # with ti.Tape(loss) automatically clears all gradients
-        with ti.Tape(loss):
+        # with ti.ad.Tape(loss) automatically clears all gradients
+        with ti.ad.Tape(loss):
             forward(visualize=visualize)
 
         print('Iter=', iter, 'Loss=', loss[None])
@@ -351,23 +352,17 @@ def optimize(toi, visualize):
 
     return losses
 
-
-robot_id = 0
-if len(sys.argv) != 3:
-    print(
-        "Usage: python3 mass_spring.py [robot_id=0, 1, 2, ...] [task=train/plot]"
-    )
-    exit(-1)
-else:
-    robot_id = int(sys.argv[1])
-    task = sys.argv[2]
-
+parser = argparse.ArgumentParser()
+parser.add_argument('robot_id', type=int, help='[robot_id=0, 1, 2, ...]')
+parser.add_argument('task', type=str, help='train/plot')
+parser.add_argument('--iters', type=int, default=100)
+options = parser.parse_args()
 
 def main():
 
-    setup_robot(*robots[robot_id]())
+    setup_robot(*robots[options.robot_id]())
 
-    if task == 'plot':
+    if options.task == 'plot':
         ret = {}
         for toi in [False, True]:
             ret[toi] = []
@@ -383,7 +378,7 @@ def main():
     else:
         optimize(toi=True, visualize=True)
         clear()
-        forward('final{}'.format(robot_id))
+        forward('final{}'.format(options.robot_id))
 
 
 if __name__ == '__main__':

--- a/examples/mass_spring_interactive.py
+++ b/examples/mass_spring_interactive.py
@@ -1,4 +1,5 @@
 from mass_spring_robot_config import robots
+import argparse
 import random
 import sys
 import matplotlib.pyplot as plt
@@ -300,12 +301,12 @@ def optimize(visualize):
 
     losses = []
     # forward('initial{}'.format(robot_id), visualize=visualize)
-    for iter in range(200):
+    for iter in range(options.iters):
         clear()
 
         import time
         t = time.time()
-        with ti.Tape(loss):
+        with ti.ad.Tape(loss):
             forward(visualize=iter % 10 == 0)
         print(time.time() - t, ' 1')
 
@@ -343,16 +344,14 @@ def optimize(visualize):
     return losses
 
 
-robot_id = 0
-if len(sys.argv) != 2:
-    print("Usage: python3 mass_spring_interactive.py [robot_id=0, 1, 2, ...]")
-    exit(0)
-else:
-    robot_id = int(sys.argv[1])
+parser = argparse.ArgumentParser()
+parser.add_argument('robot_id', type=int, help='[robot_id=0, 1, 2, ...]')
+parser.add_argument('--iters', type=int, default=200)
+options = parser.parse_args()
 
 if __name__ == '__main__':
-    setup_robot(*robots[robot_id]())
+    setup_robot(*robots[options.robot_id]())
 
     optimize(visualize=False)
     clear()
-    forward('final{}'.format(robot_id))
+    forward('final{}'.format(options.robot_id))

--- a/examples/mass_spring_simple.py
+++ b/examples/mass_spring_simple.py
@@ -180,7 +180,7 @@ def main():
     for iter in range(25):
         clear_tensors()
 
-        with ti.Tape(loss):
+        with ti.ad.Tape(loss):
             forward()
 
         print('Iter=', iter, 'Loss=', loss[None])

--- a/examples/misc/gradient_explosion.py
+++ b/examples/misc/gradient_explosion.py
@@ -37,7 +37,7 @@ def compute_loss(t: ti.i32):
 def gradient(alpha, num_steps):
     damping[None] = math.exp(-dt * alpha)
     a[None] = 1
-    with ti.Tape(loss):
+    with ti.ad.Tape(loss):
         for i in range(1, num_steps):
             advance(i)
         compute_loss(num_steps - 1)

--- a/examples/misc/rigid_body_discountinuity.py
+++ b/examples/misc/rigid_body_discountinuity.py
@@ -232,7 +232,7 @@ def main():
             # for iter in range(50):
             clear_states()
 
-            with ti.Tape(loss):
+            with ti.ad.Tape(loss):
                 forward(visualize=True)
 
             print('Iter=', i, 'Loss=', loss[None])

--- a/examples/misc/rigid_body_toi.py
+++ b/examples/misc/rigid_body_toi.py
@@ -126,7 +126,7 @@ def main():
             x[0, 0] = [0.7, 0.5 + dy]
             v[0, 0] = [-1, -2]
 
-            with ti.Tape(loss):
+            with ti.ad.Tape(loss):
                 forward(visualize=False)
 
             print('dy=', dy, 'Loss=', loss[None])

--- a/examples/rigid_body.py
+++ b/examples/rigid_body.py
@@ -463,7 +463,7 @@ def optimize(toi=True, visualize=True):
     for iter in range(20):
         clear_states()
 
-        with ti.Tape(loss):
+        with ti.ad.Tape(loss):
             forward(visualize=visualize)
 
         print('Iter=', iter, 'Loss=', loss[None])

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,8 @@
-taichi>=0.8.1
+taichi>=1.1.0
 matplotlib
 numpy
 opencv-python
 scipy
+imageio
+torch
+torchvision


### PR DESCRIPTION
This PR basically changed:
1. Add `--iters` parameter to help reduce iterations when running in release tests.
2. Move bulk taichi fields access in python scope to ti.kernel (has massive speed up).

Additionally:
1. Automatically download `bunny_128.bin` in `volume_renderer.py`
2. Add missing libs in `requirements.txt`
3. Changed `ti.Tape` to `ti.ad.Tape`